### PR TITLE
Fix edit link path

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -103,7 +103,7 @@ params:
     hiddenInSingle: true # hide on single page
 
   editPost:
-    URL: "https://github.com/ricklamers/blog/content"
+    URL: "https://github.com/ricklamers/blog/edit/main/content"
     Text: "Suggest Changes" # edit text
     appendFilePath: true # to append file path to Edit link
 


### PR DESCRIPTION
## Summary
- fix the `editPost` URL so GitHub links point to the main branch

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_685280bdf550832cbc463f8800ab03f9